### PR TITLE
Add python-click to build environment instructions

### DIFF
--- a/docs/build-blend/build_environment.md
+++ b/docs/build-blend/build_environment.md
@@ -25,7 +25,7 @@ Any subsequent commands are expected to be run in the created container.
 If you're using Arch Linux, make sure your system is up-to-date.
 
 ```bash
-sudo pacman -S git archiso base-devel xorriso python python-psutil squashfs-tools
+sudo pacman -S git archiso base-devel xorriso python python-click python-psutil squashfs-tools
 ```
 
 #### Installing `assemble`


### PR DESCRIPTION
As per #5 `assemble` does not work without install python-click in the build container.

This PR adds python-click to the instructions to set up the build environment.